### PR TITLE
Container visibility & icon bitmap fix

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/ContainerManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/ContainerManager.kt
@@ -3,12 +3,15 @@ package com.google.maps.android.compose.kml.manager
 import android.content.Context
 import android.graphics.Bitmap
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import com.google.maps.android.compose.kml.data.KmlStyle
 import com.google.maps.android.compose.kml.data.KmlStyleMap
 
 public class ContainerManager() : KmlComposableManager {
     override var style: KmlStyle = KmlStyle()
     private var containerName: String = ""
+    private var isActive: MutableState<Boolean> = mutableStateOf(true)
     private val children: MutableList<KmlComposableManager> = mutableListOf()
 
     public fun getName(): String = containerName
@@ -20,6 +23,27 @@ public class ContainerManager() : KmlComposableManager {
      */
     public fun setName(name: String) {
         containerName = name
+    }
+
+    /**
+     * Gets the current active state of the container
+     */
+    public fun getActive(): Boolean = isActive.value
+
+    /**
+     * Sets a container active or inactive. Inactive containers won't render their children
+     *
+     * @param active Active state of the container
+     */
+    public fun setActive(active: Boolean) {
+        isActive.value = active
+    }
+
+    /**
+     * Toggles the active state of the container
+     */
+    public fun toggleActive() {
+        setActive(!isActive.value)
     }
 
     /**
@@ -75,6 +99,8 @@ public class ContainerManager() : KmlComposableManager {
      */
     @Composable
     override fun Render() {
-        children.forEach { it.Render() }
+        if (isActive.value) {
+            children.forEach { it.Render() }
+        }
     }
 }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/ContainerManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/ContainerManager.kt
@@ -54,6 +54,31 @@ public class ContainerManager() : KmlComposableManager {
     public fun getContainers(): List<ContainerManager> = children.filterIsInstance<ContainerManager>()
 
     /**
+     * Gets a list of containers from a specific depth in the tree of nested ContainerManagers.
+     * When a branch can't go deeper it will return the leave
+     *
+     * @param depth The depth all containers will be returned from, if possible
+     * @return list of containers at specified depth or as deep as a branch goes
+     */
+    public fun getContainers(depth: Int): List<ContainerManager> = getContainers(depth, 0)
+
+    /**
+     * Recursive function that returns a list of containers from a specific depth
+     *
+     * @param targetDepth The depth all containers will be returned from, if possible
+     * @param currentDepth The current depth in recursion
+     * @return list of containers at specified depth or as deep as a branch goes
+     */
+    private fun getContainers(targetDepth: Int, currentDepth: Int): List<ContainerManager> {
+        val containers = getContainers()
+        return if (targetDepth == currentDepth || containers.isEmpty()) {
+            listOf(this)
+        } else {
+            containers.flatMap { it.getContainers(targetDepth, currentDepth + 1) }
+        }
+    }
+
+    /**
      * Gets a list of markers that are direct children of this ContainerManager
      * @return List of [MarkerManager]s
      */

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
@@ -182,8 +182,10 @@ public class MarkerManager(
         } else {
             Pair(DEFAULT_ICON_WIDTH, DEFAULT_ICON_HEIGHT / iconAspectRatio)
         }
-        val width = defaultWidth * scale * (dpi / icon.density)
-        val height = defaultHeight * scale * (dpi / icon.density)
+        val scaleFactor = dpi / DEFAULT_DPI
+        val width = defaultWidth * scale * scaleFactor
+        val height = defaultHeight * scale * scaleFactor
+
         return Bitmap.createScaledBitmap(icon, width.toInt(), height.toInt(), true)
     }
 
@@ -209,6 +211,7 @@ public class MarkerManager(
     }
 
     private companion object {
+        const val DEFAULT_DPI: Float = 560f
         const val DEFAULT_ICON_WIDTH: Float = 110f
         const val DEFAULT_ICON_HEIGHT: Float = 110f
     }


### PR DESCRIPTION
Containers can now be set active or inactive using two methods
```kt
val container = ContainerManager()
container.setActive(false) //sets inactive
container.toggleActive() //sets active (since last state was inactive)
```

Extra functionality to get a specific container depth
```kt
/**
*container1 //depth 0
*    container2 //depth 1
*        container3 //depth 2
*    container 4 //depth 1
*    container 5 //depth 1
*/
container.getContainers(depth = 1) //returns List<ContainerManager> { container 2, container 4, container 5 }
```
