### PR TITLE
Observer pattern for map events & ExtendedData parsing

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/event/KmlEventPublisher.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/event/KmlEventPublisher.kt
@@ -1,0 +1,30 @@
+package com.google.maps.android.compose.kml.event
+
+import com.google.maps.android.compose.kml.manager.MarkerProperties
+import java.util.concurrent.CopyOnWriteArrayList
+
+public class KmlEventPublisher {
+    private val subscribers: CopyOnWriteArrayList<(KmlEvent) -> Unit> = CopyOnWriteArrayList()
+
+    public fun subscribe(listener: (KmlEvent) -> Unit) {
+        subscribers.add(listener)
+    }
+
+    public fun unsubscribe(listener: (KmlEvent) -> Unit) {
+        subscribers.remove(listener)
+    }
+
+    internal fun emit(event: KmlEvent) {
+        subscribers.forEach { it(event) }
+    }
+}
+
+internal interface KmlEventListener {
+    fun onEvent(event: KmlEvent)
+}
+
+public sealed class KmlEvent {
+    public sealed class Marker : KmlEvent() {
+        public data class Clicked(val data: MarkerProperties) : Marker()
+    }
+}

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/ContainerManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/ContainerManager.kt
@@ -6,9 +6,9 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import com.google.maps.android.compose.kml.data.KmlStyle
 import com.google.maps.android.compose.kml.data.KmlStyleMap
+import com.google.maps.android.compose.kml.event.KmlEventListener
 
-public class ContainerManager() : KmlComposableManager {
-    override var style: KmlStyle = KmlStyle()
+public class ContainerManager : KmlComposableManager() {
     private var containerName: String = ""
     private var isActive: MutableState<Boolean> = mutableStateOf(true)
     private val children: MutableList<KmlComposableManager> = mutableListOf()
@@ -50,7 +50,8 @@ public class ContainerManager() : KmlComposableManager {
      *
      * @return List of [ContainerManager]s
      */
-    public fun getContainers(): List<ContainerManager> = children.filterIsInstance<ContainerManager>()
+    public fun getContainers(): List<ContainerManager> =
+        children.filterIsInstance<ContainerManager>()
 
     /**
      * Gets a list of containers from a specific depth in the tree of nested ContainerManagers.
@@ -84,6 +85,15 @@ public class ContainerManager() : KmlComposableManager {
     public fun getMarkers(): List<MarkerManager> = children.filterIsInstance<MarkerManager>()
 
     /**
+     * Adds a child to the ContainerManager
+     *
+     * @param child Any class extending from the [KmlComposableManager]
+     */
+    internal fun addChild(child: KmlComposableManager) {
+        children.add(child)
+    }
+
+    /**
      *  Sets properties from KML relevant to the container
      *
      *  @param data HashMap containing related properties of the container
@@ -98,7 +108,6 @@ public class ContainerManager() : KmlComposableManager {
      * @param styleMaps All StyleMap tags parsed from the KML file
      * @param styles All Style tags parsed from the KML file
      * @param images All images when present in KMZ file
-     * @param context Current context used to get information about display size
      */
     override suspend fun setStyle(
         styleMaps: HashMap<String, KmlStyleMap>,
@@ -109,12 +118,12 @@ public class ContainerManager() : KmlComposableManager {
     }
 
     /**
-     * Adds a child to the ContainerManager
+     * Sets the object that uses the KmlEventListener interface for children
      *
-     * @param child Any class extending from the [KmlComposableManager]
+     * @param eventListener KmlEventListener to be used
      */
-    internal fun addChild(child: KmlComposableManager) {
-        children.add(child)
+    override fun setEventListener(eventListener: KmlEventListener) {
+        children.forEach { it.setEventListener(eventListener) }
     }
 
     /**

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/KmlComposableManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/KmlComposableManager.kt
@@ -4,18 +4,24 @@ import android.graphics.Bitmap
 import androidx.compose.runtime.Composable
 import com.google.maps.android.compose.kml.data.KmlStyle
 import com.google.maps.android.compose.kml.data.KmlStyleMap
+import com.google.maps.android.compose.kml.event.KmlEventListener
 
-internal interface KmlComposableManager {
-    var style: KmlStyle
+public abstract class KmlComposableManager {
+    internal var style: KmlStyle = KmlStyle()
+    internal var listener: KmlEventListener? = null
 
-    suspend fun setStyle(
+    internal abstract suspend fun setStyle(
         styleMaps: HashMap<String, KmlStyleMap>,
         styles: HashMap<String, KmlStyle>,
         images: HashMap<String, Bitmap>
     )
 
-    fun setProperties(data: HashMap<String, Any>)
+    internal abstract fun setProperties(data: HashMap<String, Any>)
+
+    internal open fun setEventListener(eventListener: KmlEventListener) {
+        listener = eventListener
+    }
 
     @Composable
-    fun Render()
+    internal abstract fun Render()
 }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
@@ -2,6 +2,7 @@ package com.google.maps.android.compose.kml.manager
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -12,6 +13,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.kml.data.KmlStyle
 import com.google.maps.android.compose.kml.data.KmlStyleMap
+import com.google.maps.android.compose.kml.event.KmlEvent
 import com.google.maps.android.compose.kml.parser.Anchor
 import com.google.maps.android.compose.kml.parser.KmlStyleParser
 import com.google.maps.android.compose.rememberMarkerState
@@ -22,9 +24,8 @@ import kotlin.coroutines.suspendCoroutine
 
 public class MarkerManager(
     private val position: LatLng
-) : KmlComposableManager {
+) : KmlComposableManager() {
     private var markerData: MutableState<MarkerProperties> = mutableStateOf(MarkerProperties())
-    public override var style: KmlStyle = KmlStyle()
 
     override fun setProperties(data: HashMap<String, Any>) {
         markerData.value = MarkerProperties.from(data)
@@ -36,7 +37,6 @@ public class MarkerManager(
      * @param styleMaps All StyleMap tags parsed from the KML file
      * @param styles All Style tags parsed from the KML file
      * @param images All images when present in KMZ file
-     * @param context Current context used to get information about display size
      */
     public override suspend fun setStyle(
         styleMaps: HashMap<String, KmlStyleMap>,
@@ -218,6 +218,11 @@ public class MarkerManager(
             visible = currentMarkerData.visibility,
             zIndex = currentMarkerData.drawOrder,
             icon = getIcon(currentMarkerData.icon),
+            onClick = {
+                Log.e("Marker composable", "onClick")
+                listener?.onEvent(KmlEvent.Marker.Clicked(markerData.value))
+                true
+            }
         )
     }
 
@@ -229,9 +234,9 @@ public class MarkerManager(
 }
 
 /**
- * Internal helper data class containing all maker properties and styles
+ * Helper data class containing all maker properties and styles
  */
-internal data class MarkerProperties(
+public data class MarkerProperties(
     val description: String = DEFAULT_DESCRIPTION,
     val name: String = DEFAULT_NAME,
     val visibility: Boolean = DEFAULT_VISIBILITY,
@@ -241,9 +246,9 @@ internal data class MarkerProperties(
     val rotation: Int = DEFAULT_ROTATION,
     val color: Float? = DEFAULT_COLOR,
     val styleUrl: String? = DEFAULT_STYLE_URL,
-    var icon: Bitmap? = DEFAULT_ICON,
+    val icon: Bitmap? = DEFAULT_ICON,
 ) {
-    companion object {
+    internal companion object {
         internal fun from(properties: HashMap<String, Any>): MarkerProperties {
             val description: String by properties.withDefault { DEFAULT_DESCRIPTION }
             val name: String by properties.withDefault { DEFAULT_NAME }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
@@ -2,7 +2,6 @@ package com.google.maps.android.compose.kml.manager
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -219,7 +218,6 @@ public class MarkerManager(
             zIndex = currentMarkerData.drawOrder,
             icon = getIcon(currentMarkerData.icon),
             onClick = {
-                Log.e("Marker composable", "onClick")
                 listener?.onEvent(KmlEvent.Marker.Clicked(markerData.value))
                 true
             }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
@@ -247,6 +247,7 @@ public data class MarkerProperties(
     val color: Float? = DEFAULT_COLOR,
     val styleUrl: String? = DEFAULT_STYLE_URL,
     val icon: Bitmap? = DEFAULT_ICON,
+    val extendedData: HashMap<String, String>? = DEFAULT_EXTENDED_DATA
 ) {
     internal companion object {
         internal fun from(properties: HashMap<String, Any>): MarkerProperties {
@@ -255,6 +256,7 @@ public data class MarkerProperties(
             val visibility: Boolean by properties.withDefault { DEFAULT_VISIBILITY }
             val drawOrder: Float by properties.withDefault { DEFAULT_DRAW_ORDER }
             val styleUrl: String? by properties
+            val extendedData: HashMap<String, String>? = properties["ExtendedData"] as? HashMap<String, String>
             return MarkerProperties(
                 description = description,
                 name = name,
@@ -265,7 +267,8 @@ public data class MarkerProperties(
                 rotation = DEFAULT_ROTATION,
                 color = DEFAULT_COLOR,
                 styleUrl = styleUrl,
-                icon = DEFAULT_ICON
+                icon = DEFAULT_ICON,
+                extendedData = extendedData
             )
         }
 
@@ -279,5 +282,6 @@ public data class MarkerProperties(
         private val DEFAULT_COLOR = null
         private const val DEFAULT_STYLE_URL = ""
         private val DEFAULT_ICON = null
+        private val DEFAULT_EXTENDED_DATA = null
     }
 }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlParser.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlParser.kt
@@ -1,7 +1,6 @@
 package com.google.maps.android.compose.kml.parser
 
 import android.graphics.Bitmap
-import android.util.Log
 import com.google.maps.android.compose.kml.data.KmlStyle
 import com.google.maps.android.compose.kml.data.KmlStyleMap
 import com.google.maps.android.compose.kml.event.KmlEvent
@@ -24,7 +23,6 @@ public class KmlParser(
     public val eventPublisher: KmlEventPublisher = KmlEventPublisher(),
 ): KmlEventListener {
     override fun onEvent(event: KmlEvent) {
-        Log.e("KmlParser", "${event}")
         eventPublisher.emit(event)
     }
 

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlParser.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlParser.kt
@@ -1,8 +1,12 @@
 package com.google.maps.android.compose.kml.parser
 
 import android.graphics.Bitmap
+import android.util.Log
 import com.google.maps.android.compose.kml.data.KmlStyle
 import com.google.maps.android.compose.kml.data.KmlStyleMap
+import com.google.maps.android.compose.kml.event.KmlEvent
+import com.google.maps.android.compose.kml.event.KmlEventListener
+import com.google.maps.android.compose.kml.event.KmlEventPublisher
 import com.google.maps.android.compose.kml.manager.ContainerManager
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserException
@@ -17,7 +21,13 @@ public class KmlParser(
     private val styleMaps: HashMap<String, KmlStyleMap> = hashMapOf(),
     private val styles: HashMap<String, KmlStyle> = hashMapOf(),
     public var container: ContainerManager = ContainerManager(),
-) {
+    public val eventPublisher: KmlEventPublisher = KmlEventPublisher(),
+): KmlEventListener {
+    override fun onEvent(event: KmlEvent) {
+        Log.e("KmlParser", "${event}")
+        eventPublisher.emit(event)
+    }
+
     /**
      * Parses the KML file stored in the current XmlPullParser.
      * Creates a ContainerManager that stores the relevant data of the KML file.
@@ -98,6 +108,10 @@ public class KmlParser(
         container.setStyle(styleMaps, styles, images)
     }
 
+    internal fun setEventListener(listener: KmlEventListener) {
+        container.setEventListener(listener)
+    }
+
     public companion object {
         internal const val STYLE_TAG = "Style"
         internal const val STYLE_MAP_TAG = "StyleMap"
@@ -128,6 +142,7 @@ public class KmlParser(
             val parsedKmlData = MapFileParser.parseStream(inputStream)
             parsedKmlData.parser?.let {
                 it.applyStyles(parsedKmlData.media)
+                it.setEventListener(it)
                 return it
             }
             return null

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlPlacemarkParser.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlPlacemarkParser.kt
@@ -73,16 +73,19 @@ internal class KmlPlacemarkParser {
 
         private fun parseExtendedData(parser: XmlPullParser): HashMap<String, String> {
             val extendedData = hashMapOf<String, String>()
-            var currentData: String = ""
+            var currentData = ExtendedData.empty()
             var eventType = parser.eventType
             while (!(eventType == XmlPullParser.END_TAG && parser.name.equals(EXTENDED_DATA_TAG))) {
                 if (eventType == XmlPullParser.START_TAG) {
                     when (parser.name) {
                         DATA_TAG ->
-                            currentData = parser.getAttributeValue(null, "name")
+                            currentData.name = parser.getAttributeValue(null, "name")
+
+                        DISPLAY_NAME_TAG ->
+                            currentData.displayName = parser.nextText()
 
                         VALUE_TAG ->
-                            extendedData[currentData] = parser.nextText()
+                            currentData.value = parser.nextText()
                     }
                 }
                 eventType = parser.next()
@@ -107,6 +110,7 @@ internal class KmlPlacemarkParser {
         private const val EXTENDED_DATA_TAG = "ExtendedData"
         private const val DATA_TAG = "Data"
         private const val VALUE_TAG = "value"
+        private const val DISPLAY_NAME_TAG = "displayName"
     }
 
     /**
@@ -138,6 +142,16 @@ internal class KmlPlacemarkParser {
                 val latLng = LatLng(lat, lng)
                 return LatLngAlt(latLng, alt)
             }
+        }
+    }
+
+    data class ExtendedData(
+        var name: String,
+        var displayName: String?,
+        var value: String
+    ) {
+        companion object {
+            fun empty(): ExtendedData = ExtendedData(name = "", displayName = null, value = "")
         }
     }
 }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlPlacemarkParser.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlPlacemarkParser.kt
@@ -65,7 +65,7 @@ internal class KmlPlacemarkParser {
             }
 
             if (latLngAlt == null) {
-                throw IllegalArgumentException("KML ")
+                throw IllegalArgumentException("KML doesn't contain coordinates for placemark point")
             }
 
             return MarkerManager(latLngAlt.latLng)


### PR DESCRIPTION
### Observer pattern
`KmlParser` now has a `KmlEventPublisher` public variable that a developer can subscribe on, receiving `KmlEvent`s

### `<ExtendedData>`
Added extendedData parsing as preparation for Placemark information.
ExtendedData is saved in a Hashmap, where the key is the name of the `<data name="...">` tag and the value is the contents of the `<value>...</value>` tag