### PR TITLE
Polyline UnitTests & fix convertPropertyToFloat method

### DIFF
--- a/maps-compose-utils/build.gradle
+++ b/maps-compose-utils/build.gradle
@@ -43,4 +43,14 @@ dependencies {
     implementation "androidx.compose.ui:ui:1.6.3"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.22"
     api "com.google.maps.android:maps-utils-ktx:5.0.0"
+
+    testImplementation "junit:junit:4.13.2"
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1-Beta'
+    testImplementation "org.mockito:mockito-core:3.12.4"
+    testImplementation 'net.sf.kxml:kxml2:2.3.0'
+
+    androidTestImplementation "org.mockito:mockito-core:3.12.4"
+    androidTestImplementation platform("androidx.compose:compose-bom:2024.01.00")
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
+    androidTestImplementation "androidx.test.ext:junit-ktx:1.1.5"
 }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/data/KmlTags.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/data/KmlTags.kt
@@ -7,6 +7,7 @@ internal class KmlTags {
         const val DATA_TAG = "Data"
         const val DESCRIPTION_TAG = "description"
         const val DISPLAY_NAME_TAG = "displayName"
+        const val DRAW_ORDER_TAG = "drawOrder"
         const val EXTENDED_DATA_TAG = "ExtendedData"
         const val GROUND_OVERLAY_TAG = "GroundOverlay"
         const val HREF_TAG = "href"

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/KmlComposableManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/KmlComposableManager.kt
@@ -2,6 +2,7 @@ package com.google.maps.android.compose.kml.manager
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.util.Log
 import androidx.compose.runtime.Composable
 import com.google.maps.android.compose.kml.data.KmlStyle
 import com.google.maps.android.compose.kml.data.KmlStyleMap
@@ -44,6 +45,11 @@ public abstract class KmlComposableManager {
 
         if (url.lowercase().startsWith("https")) {
             fetchImageFromUrl(url)?.let { return it }
+        } else if (url.lowercase().startsWith("http")) {
+            Log.w(
+                "KML fetchBitmap",
+                "http is not supported, use https instead"
+            )
         }
 
         return null

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/PolylineManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/PolylineManager.kt
@@ -13,12 +13,14 @@ import com.google.android.gms.maps.model.PatternItem
 import com.google.maps.android.compose.Polyline
 import com.google.maps.android.compose.kml.data.KmlStyle
 import com.google.maps.android.compose.kml.data.KmlStyleMap
+import com.google.maps.android.compose.kml.data.KmlTags.Companion.DRAW_ORDER_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.EXTENDED_DATA_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.TESSELLATE_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.VISIBILITY_TAG
 import com.google.maps.android.compose.kml.event.KmlEvent
 import com.google.maps.android.compose.kml.parser.ExtendedData
 import com.google.maps.android.compose.kml.parser.KmlParser.Companion.convertPropertyToBoolean
+import com.google.maps.android.compose.kml.parser.KmlParser.Companion.convertPropertyToFloat
 
 public class PolylineManager(
     private val coordinates: List<LatLng>
@@ -29,6 +31,8 @@ public class PolylineManager(
     override fun setProperties(data: HashMap<String, Any>) {
         polylineData.value = PolylineProperties.from(data)
     }
+
+    public fun getProperties(): PolylineProperties = polylineData.value.copy()
 
     override suspend fun setStyle(
         styleMaps: HashMap<String, KmlStyleMap>,
@@ -156,7 +160,7 @@ public class PolylineManager(
                 val description: String by properties.withDefault { DEFAULT_DESCRIPTION }
                 val visibility: Boolean =
                     convertPropertyToBoolean(properties, VISIBILITY_TAG, DEFAULT_VISIBILITY)
-                val drawOrder: Float by properties.withDefault { DEFAULT_DRAW_ORDER }
+                val drawOrder: Float = convertPropertyToFloat(properties, DRAW_ORDER_TAG, DEFAULT_DRAW_ORDER)
                 val styleUrl: String? by properties.withDefault { DEFAULT_STYLE_URL }
                 val extendedData: List<ExtendedData>? =
                     properties[EXTENDED_DATA_TAG] as? List<ExtendedData>

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlFeatureParser.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlFeatureParser.kt
@@ -4,6 +4,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.DATA_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.DESCRIPTION_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.DISPLAY_NAME_TAG
+import com.google.maps.android.compose.kml.data.KmlTags.Companion.DRAW_ORDER_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.EXTENDED_DATA_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.NAME_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.STYLE_URL_TAG
@@ -60,7 +61,7 @@ internal abstract class KmlFeatureParser {
         }
 
         internal val PROPERTY_REGEX =
-            Regex("$NAME_TAG|$DESCRIPTION_TAG|drawOrder|$VISIBILITY_TAG|address|phoneNumber|$STYLE_URL_TAG|$TESSELLATE_TAG")
+            Regex("$NAME_TAG|$DESCRIPTION_TAG|$DRAW_ORDER_TAG|$VISIBILITY_TAG|address|phoneNumber|$STYLE_URL_TAG|$TESSELLATE_TAG")
         private const val LONGITUDE_INDEX = 0
         private const val LATITUDE_INDEX = 1
         private const val LAT_LNG_ALT_SEPARATOR = ","

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlParser.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlParser.kt
@@ -140,6 +140,15 @@ public class KmlParser(
             return value?.let { it == "1" } ?: defaultValue
         }
 
+        internal fun convertPropertyToFloat(
+            properties: HashMap<String, Any>,
+            key: String,
+            defaultValue: Float = 1f
+        ): Float {
+            val value = properties[key] as? String
+            return value?.toFloat() ?: defaultValue
+        }
+
         /**
          * Parses an input KML/KMZ file and returns a KmlParser
          * containing all information if parsed successfully

--- a/maps-compose-utils/src/test/java/KmlParserContainerTest.kt
+++ b/maps-compose-utils/src/test/java/KmlParserContainerTest.kt
@@ -5,10 +5,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
 public class KmlParserContainerTest {
     private lateinit var parser: KmlParser
 

--- a/maps-compose-utils/src/test/java/KmlParserContainerTest.kt
+++ b/maps-compose-utils/src/test/java/KmlParserContainerTest.kt
@@ -1,0 +1,33 @@
+
+import com.google.maps.android.compose.kml.parser.KmlParser
+import com.google.maps.android.compose.kml.parser.MapFileParser
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+public class KmlParserContainerTest {
+    private lateinit var parser: KmlParser
+
+    @Before
+    public fun setUp(): Unit = runBlocking {
+        val containerNestingKml = javaClass.classLoader?.getResourceAsStream("ContainersNesting.kml")
+            ?: throw AssertionError("Could not load sample KML file")
+        val parsedKmlData = MapFileParser.parseStream(containerNestingKml)
+        parsedKmlData.parser?.applyStyles(parsedKmlData.media)
+        parser = parsedKmlData.parser!!
+    }
+
+    @Test
+    public fun testRootContainerNameMatches() {
+        Assert.assertEquals(parser.container.getName(), "Root Document")
+    }
+
+    @Test
+    public fun testRootContainerNameIsNotChilds() {
+        Assert.assertNotEquals(parser.container.getName(), parser.container.getContainers().first().getName())
+    }
+}

--- a/maps-compose-utils/src/test/java/KmlParserPolylineTest.kt
+++ b/maps-compose-utils/src/test/java/KmlParserPolylineTest.kt
@@ -1,0 +1,410 @@
+
+import androidx.compose.ui.graphics.Color
+import com.google.android.gms.maps.model.ButtCap
+import com.google.android.gms.maps.model.Dash
+import com.google.android.gms.maps.model.Dot
+import com.google.android.gms.maps.model.Gap
+import com.google.android.gms.maps.model.JointType
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.RoundCap
+import com.google.android.gms.maps.model.SquareCap
+import com.google.maps.android.compose.kml.manager.PolylineManager
+import com.google.maps.android.compose.kml.parser.KmlParser
+import com.google.maps.android.compose.kml.parser.MapFileParser
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.lang.reflect.Field
+import kotlin.math.round
+
+/**
+ * For this test the file "PolylineTest.kml" has been written with variations of a <LineString>
+ * In total there are 6 lines defined each with different values, the following list will show the variations
+ *
+ *  ┌───────────────┐   ┌───────────────┐   ┌────────────────────────────┐
+ *  │ first         │   │ second        │   │ third                      │
+ *  ├───────────────┤   ├───────────────┤   ├────────────────────────────┤
+ *  │ Points:   3   │   │ Points:   1   │   │ Points:   4                │
+ *  │ Color    Black│   │ Color    Red  │   │ Color    Red (~50% alpha)  │
+ *  │ Geodesic: 1   │   │ Geodesic: 1   │   │ Geodesic: 1                │
+ *  │ Visible:  1   │   │ Visible:  1   │   │ Visible:  0                │
+ *  │ Width:    1   │   │ Width:    15  │   │ Width:    20               │
+ *  │ zIndex:   1   │   │ zIndex:   2   │   │ zIndex:   3                │
+ *  └───────────────┘   └───────────────┘   └────────────────────────────┘
+ *  ┌────────────────┐   ┌───────────────┐   ┌───────────────────┐
+ *  │ fourth         │   │ fifth         │   │ sixth             │
+ *  ├────────────────┤   ├───────────────┤   ├───────────────────┤
+ *  │ Points:   3    │   │ Points:   3   │   │ Points:   40      │
+ *  │ Color    Cyan  │   │ Color    Black│   │ Color     unset   │
+ *  │ Geodesic: 0    │   │ Geodesic: 0   │   │ Geodesic: unset   │
+ *  │ Visible:  0    │   │ Visible:  0   │   │ Visible:  unset   │
+ *  │ Width:    25   │   │ Width:    100 │   │ Width:    unset   │
+ *  │ zIndex:   4    │   │ zIndex:   5   │   │ zIndex:   unset   │
+ *  └────────────────┘   └───────────────┘   └───────────────────┘
+ *
+ *  The Points represent the amount of positions, starts from 52.509,6.087 and continue down 1 third decimal at the time.
+ */
+
+public class KmlParserPolylineTest {
+    private lateinit var parser: KmlParser
+    private val testPositions = listOf(
+        LatLng(52.509,6.087),
+        LatLng(52.508,6.086),
+        LatLng(52.507,6.085),
+        LatLng(52.506,6.084),
+        LatLng(52.505,6.083),
+        LatLng(52.504,6.082),
+        LatLng(52.503,6.081),
+        LatLng(52.502,6.080),
+        LatLng(52.501,6.079),
+        LatLng(52.500,6.078),
+        LatLng(52.499,6.077),
+        LatLng(52.498,6.076),
+        LatLng(52.497,6.075),
+        LatLng(52.496,6.074),
+        LatLng(52.495,6.073),
+        LatLng(52.494,6.072),
+        LatLng(52.493,6.071),
+        LatLng(52.492,6.070),
+        LatLng(52.491,6.069),
+        LatLng(52.490,6.068),
+        LatLng(52.489,6.067),
+        LatLng(52.488,6.066),
+        LatLng(52.487,6.065),
+        LatLng(52.486,6.064),
+        LatLng(52.485,6.063),
+        LatLng(52.484,6.062),
+        LatLng(52.483,6.061),
+        LatLng(52.482,6.060),
+        LatLng(52.481,6.059),
+        LatLng(52.480,6.058),
+        LatLng(52.479,6.057),
+        LatLng(52.478,6.056),
+        LatLng(52.477,6.055),
+        LatLng(52.476,6.054),
+        LatLng(52.475,6.053),
+        LatLng(52.474,6.052),
+        LatLng(52.473,6.051),
+        LatLng(52.472,6.050),
+        LatLng(52.471,6.049),
+        LatLng(52.470,6.048)
+    )
+
+    private data class TestLines(
+        val line1: PolylineManager,
+        val line2: PolylineManager,
+        val line3: PolylineManager,
+        val line4: PolylineManager,
+        val line5: PolylineManager,
+        val line6: PolylineManager
+    )
+
+    private fun getTestLines(): TestLines {
+        val lines = parser.container.getPolylines()
+        val line1 = lines.find { it.getProperties().name == "first" }!!
+        val line2 = lines.find { it.getProperties().name == "second" }!!
+        val line3 = lines.find { it.getProperties().name == "third" }!!
+        val line4 = lines.find { it.getProperties().name == "fourth" }!!
+        val line5 = lines.find { it.getProperties().name == "fifth" }!!
+        val line6 = lines.find { it.getProperties().name == "sixth" }!!
+
+        return TestLines(line1, line2, line3, line4, line5, line6)
+    }
+
+    private fun getCoordinates(manager: PolylineManager): List<LatLng> {
+        val field: Field = PolylineManager::class.java.getDeclaredField("coordinates")
+        field.isAccessible = true
+        return field.get(manager) as List<LatLng>
+    }
+
+    @Before
+    public fun setUp(): Unit = runBlocking {
+        val containerNestingKml = javaClass.classLoader?.getResourceAsStream("PolylineTest.kml")
+            ?: throw AssertionError("Could not load sample KML file")
+        val parsedKmlData = MapFileParser.parseStream(containerNestingKml)
+        parsedKmlData.parser?.applyStyles(parsedKmlData.media)
+        parser = parsedKmlData.parser!!
+    }
+
+    @Test
+    public fun testContainerContainingAllLines() {
+        val lines = parser.container.getPolylines()
+        Assert.assertEquals(6, lines.count())
+    }
+
+    @Test
+    public fun testCorrectNameParsed() {
+        val lines = parser.container.getPolylines()
+        val line1 = lines.find { it.getProperties().name == "first" }
+        val line2 = lines.find { it.getProperties().name == "second" }
+        val line3 = lines.find { it.getProperties().name == "third" }
+        val line4 = lines.find { it.getProperties().name == "fourth" }
+        val line5 = lines.find { it.getProperties().name == "fifth" }
+        val line6 = lines.find { it.getProperties().name == "sixth" }
+
+        Assert.assertNotNull(line1)
+        Assert.assertNotNull(line2)
+        Assert.assertNotNull(line3)
+        Assert.assertNotNull(line4)
+        Assert.assertNotNull(line5)
+        Assert.assertNotNull(line6)
+    }
+
+    @Test
+    public fun testPointsAmountCorrect() {
+        val lines = getTestLines()
+
+        Assert.assertEquals(3, getCoordinates(lines.line1).count())
+        Assert.assertEquals(1, getCoordinates(lines.line2).count())
+        Assert.assertEquals(4, getCoordinates(lines.line3).count())
+        Assert.assertEquals(4, getCoordinates(lines.line4).count())
+        Assert.assertEquals(4, getCoordinates(lines.line5).count())
+        Assert.assertEquals(40, getCoordinates(lines.line6).count())
+    }
+
+    @Test
+    public fun testPointsAmountNotWrong() {
+        val lines = getTestLines()
+
+        Assert.assertNotEquals(1, getCoordinates(lines.line1).count())
+        Assert.assertNotEquals(3, getCoordinates(lines.line2).count())
+        Assert.assertNotEquals(40, getCoordinates(lines.line3).count())
+        Assert.assertNotEquals(40, getCoordinates(lines.line4).count())
+        Assert.assertNotEquals(40, getCoordinates(lines.line5).count())
+        Assert.assertNotEquals(0, getCoordinates(lines.line6).count())
+    }
+
+    @Test
+    public fun testPointsLine1CorrectLatLongs() {
+        val line = getTestLines().line1
+        val coordinates = getCoordinates(line)
+
+        Assert.assertEquals(testPositions[0], coordinates[0])
+        Assert.assertEquals(testPositions[1], coordinates[1])
+        Assert.assertEquals(testPositions[2], coordinates[2])
+    }
+
+    @Test
+    public fun testPointsLine2CorrectLatLongs() {
+        val line = getTestLines().line2
+
+        Assert.assertEquals(testPositions[0], getCoordinates(line)[0])
+    }
+
+    @Test
+    public fun testPointsLine3CorrectLatLongs() {
+        val line = getTestLines().line3
+        val coordinates = getCoordinates(line)
+
+        Assert.assertEquals(testPositions[0], coordinates[0])
+        Assert.assertEquals(testPositions[1], coordinates[1])
+        Assert.assertEquals(testPositions[2], coordinates[2])
+        Assert.assertEquals(testPositions[3], coordinates[3])
+    }
+
+    @Test
+    public fun testPointsLine4CorrectLatLongs() {
+        val line = getTestLines().line4
+        val coordinates = getCoordinates(line)
+
+        Assert.assertEquals(testPositions[0], coordinates[0])
+        Assert.assertEquals(testPositions[1], coordinates[1])
+        Assert.assertEquals(testPositions[2], coordinates[2])
+        Assert.assertEquals(testPositions[3], coordinates[3])
+    }
+
+    @Test
+    public fun testPointsLine5CorrectLatLongs() {
+        val line = getTestLines().line5
+        val coordinates = getCoordinates(line)
+
+        Assert.assertEquals(testPositions[0], coordinates[0])
+        Assert.assertEquals(testPositions[1], coordinates[1])
+        Assert.assertEquals(testPositions[2], coordinates[2])
+        Assert.assertEquals(testPositions[3], coordinates[3])
+    }
+
+    @Test
+    public fun testPointsLine6CorrectLatLongs() {
+        val line = getTestLines().line6
+        val coordinates = getCoordinates(line)
+
+        coordinates.forEachIndexed {index, latLng ->
+            Assert.assertEquals(testPositions[index], latLng)
+        }
+    }
+
+    @Test
+    public fun testColorLine1CorrectColor() {
+        val line = getTestLines().line1
+        val color = line.getProperties().color
+
+        Assert.assertEquals(1f, color.alpha)
+        Assert.assertEquals(0f, color.red)
+        Assert.assertEquals(0f, color.blue)
+        Assert.assertEquals(0f, color.green)
+    }
+
+    @Test
+    public fun testColorLine2CorrectColor() {
+        val line = getTestLines().line2
+        val color = line.getProperties().color
+
+        Assert.assertEquals(1f, color.alpha)
+        Assert.assertEquals(1f, color.red)
+        Assert.assertEquals(0f, color.blue)
+        Assert.assertEquals(0f, color.green)
+    }
+
+    @Test
+    public fun testColorLine3CorrectColor() {
+        val line = getTestLines().line3
+        val color = line.getProperties().color
+
+        Assert.assertEquals(.5f, round(color.alpha * 10) / 10)
+        Assert.assertEquals(1f, color.red)
+        Assert.assertEquals(0f, color.blue)
+        Assert.assertEquals(0f, color.green)
+    }
+
+    @Test
+    public fun testColorLine4CorrectColor() {
+        val line = getTestLines().line4
+        val color = line.getProperties().color
+
+        Assert.assertEquals(1f, color.alpha)
+        Assert.assertEquals(0f, color.red)
+        Assert.assertEquals(1f, color.blue)
+        Assert.assertEquals(1f, color.green)
+    }
+
+    @Test
+    public fun testColorLine5CorrectColor() {
+        val line = getTestLines().line5
+        val color = line.getProperties().color
+
+        Assert.assertEquals(1f, color.alpha)
+        Assert.assertEquals(0f, color.red)
+        Assert.assertEquals(0f, color.blue)
+        Assert.assertEquals(1f, color.green)
+    }
+
+    @Test
+    public fun testColorLine6CorrectColor() {
+        val line = getTestLines().line1
+        val color = line.getProperties().color
+        val defaultColor = Color.Black // taken from PolylineManager Companion object DEFAULT_COLOR
+
+        Assert.assertEquals(defaultColor, color)
+    }
+
+    @Test
+    public fun testTessellateLinesCorrectGeodesic() {
+        val lines = getTestLines()
+        val defaultTessellate = false // taken from PolylineManager Companion object DEFAULT_TESSELLATE
+
+        Assert.assertEquals(true, lines.line1.getProperties().tessellate)
+        Assert.assertEquals(true, lines.line2.getProperties().tessellate)
+        Assert.assertEquals(true, lines.line3.getProperties().tessellate)
+        Assert.assertEquals(false, lines.line4.getProperties().tessellate)
+        Assert.assertEquals(false, lines.line5.getProperties().tessellate)
+        Assert.assertEquals(defaultTessellate, lines.line6.getProperties().tessellate)
+    }
+
+    @Test
+    public fun testVisibilityLines() {
+        val lines = getTestLines()
+        val defaultVisibility = true // taken from KmlComposableManager Companion object DEFAULT_VISIBILITY
+
+        Assert.assertEquals(true, lines.line1.getProperties().visibility)
+        Assert.assertEquals(true, lines.line2.getProperties().visibility)
+        Assert.assertEquals(false, lines.line3.getProperties().visibility)
+        Assert.assertEquals(false, lines.line4.getProperties().visibility)
+        Assert.assertEquals(false, lines.line5.getProperties().visibility)
+        Assert.assertEquals(defaultVisibility, lines.line6.getProperties().visibility)
+    }
+
+    @Test
+    public fun testWidthLines() {
+        val lines = getTestLines()
+        val defaultWith = 1f // taken from PolylineManager Companion object DEFAULT_WIDTH
+
+        Assert.assertEquals(1f, lines.line1.getProperties().width)
+        Assert.assertEquals(15f, lines.line2.getProperties().width)
+        Assert.assertEquals(20f, lines.line3.getProperties().width)
+        Assert.assertEquals(25f, lines.line4.getProperties().width)
+        Assert.assertEquals(100f, lines.line5.getProperties().width)
+        Assert.assertEquals(defaultWith, lines.line6.getProperties().width)
+    }
+
+    @Test
+    public fun testDrawOrderLinesZIndex() {
+        val lines = getTestLines()
+        val defaultDrawOrder = 0f // taken from KmlComposableManager Companion object DEFAULT_DRAW_ORDER
+
+        Assert.assertEquals(1f, lines.line1.getProperties().drawOrder)
+        Assert.assertEquals(2f, lines.line2.getProperties().drawOrder)
+        Assert.assertEquals(3f, lines.line3.getProperties().drawOrder)
+        Assert.assertEquals(4f, lines.line4.getProperties().drawOrder)
+        Assert.assertEquals(5f, lines.line5.getProperties().drawOrder)
+        Assert.assertEquals(defaultDrawOrder, lines.line6.getProperties().drawOrder)
+    }
+
+    @Test
+    public fun testEndCapSetter() {
+        val line = getTestLines().line1
+
+        line.setEndCap(RoundCap())
+
+        Assert.assertEquals(RoundCap::class.java, line.getProperties().endCap::class.java)
+        Assert.assertNotEquals(ButtCap::class.java, line.getProperties().endCap::class.java)
+        Assert.assertNotEquals(SquareCap::class.java, line.getProperties().endCap::class.java)
+    }
+
+    @Test
+    public fun testStartCapSetter() {
+        val line = getTestLines().line1
+        line.setStartCap(SquareCap())
+
+        Assert.assertEquals(SquareCap::class.java, line.getProperties().startCap::class.java)
+        Assert.assertNotEquals(ButtCap::class.java, line.getProperties().startCap::class.java)
+        Assert.assertNotEquals(RoundCap::class.java, line.getProperties().startCap::class.java)
+    }
+
+    @Test
+    public fun testDefaultJointTypeLine() {
+        val lines = getTestLines()
+        val defaultJointType = JointType.DEFAULT // taken from PolylineManager Companion object DEFAULT_JOINT_TYPE
+
+        Assert.assertEquals(defaultJointType, lines.line1.getProperties().jointType)
+        Assert.assertEquals(defaultJointType, lines.line2.getProperties().jointType)
+        Assert.assertEquals(defaultJointType, lines.line3.getProperties().jointType)
+        Assert.assertEquals(defaultJointType, lines.line4.getProperties().jointType)
+        Assert.assertEquals(defaultJointType, lines.line5.getProperties().jointType)
+        Assert.assertEquals(defaultJointType, lines.line6.getProperties().jointType)
+    }
+
+    @Test
+    public fun testJointTypeSetter() {
+        val line = getTestLines().line1
+        val expectedType = JointType.ROUND
+        line.setJointType(expectedType)
+
+        Assert.assertEquals(expectedType, line.getProperties().jointType)
+    }
+
+    @Test
+    public fun testPatternSetter() {
+        val line = getTestLines().line1
+        val expectedPattern = mutableListOf(
+            Gap(10f),
+            Dash(5f),
+            Gap(15f),
+            Dot()
+        )
+        line.setPattern(expectedPattern)
+
+        Assert.assertEquals(expectedPattern, line.getProperties().pattern)
+    }
+}

--- a/maps-compose-utils/src/test/resources/ContainersNesting.kml
+++ b/maps-compose-utils/src/test/resources/ContainersNesting.kml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <!-- Root Document -->
+    <name>Root Document</name>
+    <Folder>
+      <!-- First Folder -->
+      <name>Folder 1</name>
+      <Folder>
+        <!-- Nested Folder -->
+        <name>Folder 2</name>
+        <Folder>
+          <!-- Another Nested Folder -->
+          <name>Folder 3</name>
+        </Folder>
+      </Folder>
+    </Folder>
+    <Folder>
+      <!-- Second Folder -->
+      <name>Folder 4</name>
+      <Document>
+        <!-- Nested Document -->
+        <name>Document 1</name>
+        <Folder>
+          <!-- Nested Folder inside Document -->
+          <name>Folder 5</name>
+        </Folder>
+      </Document>
+    </Folder>
+  </Document>
+</kml>

--- a/maps-compose-utils/src/test/resources/PolylineTest.kml
+++ b/maps-compose-utils/src/test/resources/PolylineTest.kml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Document>
+        <name>Root Document</name>
+
+        <!-- First line -->
+        <Style id="first-normal">
+          <LineStyle>
+            <color>ff000000</color>
+            <width>1</width>
+          </LineStyle>
+        </Style>
+        <StyleMap id="first">
+          <Pair>
+            <key>normal</key>
+            <styleUrl>#first-normal</styleUrl>
+          </Pair>
+        </StyleMap>
+        <Placemark>
+            <name>first</name>
+            <styleUrl>#first</styleUrl>
+            <visibility>1</visibility>
+            <LineString>
+                <tessellate>1</tessellate>
+                <drawOrder>1</drawOrder>
+                <coordinates>
+                    6.087,52.509,0
+                    6.086,52.508,0
+                    6.085,52.507,0
+                </coordinates>
+            </LineString>
+        </Placemark>
+
+        <!-- Second line -->
+        <Style id="second-normal">
+          <LineStyle>
+            <color>ff0000ff</color>
+            <width>15</width>
+          </LineStyle>
+        </Style>
+        <StyleMap id="second">
+          <Pair>
+            <key>normal</key>
+            <styleUrl>#second-normal</styleUrl>
+          </Pair>
+        </StyleMap>
+        <Placemark>
+            <name>second</name>
+            <styleUrl>#second</styleUrl>
+            <visibility>1</visibility>
+            <LineString>
+                <tessellate>1</tessellate>
+                <drawOrder>2</drawOrder>
+                <coordinates>
+                    6.087,52.509,0
+                </coordinates>
+            </LineString>
+        </Placemark>
+
+        <!-- Third line -->
+        <Style id="third-normal">
+          <LineStyle>
+            <color>7f0000ff</color> <!-- Approx 50% alpha -->
+            <width>20</width>
+          </LineStyle>
+        </Style>
+        <StyleMap id="third">
+          <Pair>
+            <key>normal</key>
+            <styleUrl>#third-normal</styleUrl>
+          </Pair>
+        </StyleMap>
+        <Placemark>
+            <name>third</name>
+            <styleUrl>#third</styleUrl>
+            <visibility>0</visibility>
+            <LineString>
+                <tessellate>1</tessellate>
+                <drawOrder>3</drawOrder>
+                <coordinates>
+                    6.087,52.509,0
+                    6.086,52.508,0
+                    6.085,52.507,0
+                    6.084,52.506,0
+                </coordinates>
+            </LineString>
+        </Placemark>
+
+        <!-- Fourth line -->
+        <Style id="fourth-normal">
+          <LineStyle>
+            <color>ffffff00</color>
+            <width>25</width>
+          </LineStyle>
+        </Style>
+        <StyleMap id="fourth">
+          <Pair>
+            <key>normal</key>
+            <styleUrl>#fourth-normal</styleUrl>
+          </Pair>
+        </StyleMap>
+        <Placemark>
+            <name>fourth</name>
+            <styleUrl>#fourth</styleUrl>
+            <visibility>0</visibility>
+            <LineString>
+                <tessellate>0</tessellate>
+                <drawOrder>4</drawOrder>
+                <coordinates>
+                    6.087,52.509,0
+                    6.086,52.508,0
+                    6.085,52.507,0
+                    6.084,52.506,0
+                </coordinates>
+            </LineString>
+        </Placemark>
+
+        <!-- Fifth line -->
+        <Style id="fifth-normal">
+          <LineStyle>
+            <color>ff00ff00</color>
+            <width>100</width>
+          </LineStyle>
+        </Style>
+        <StyleMap id="fifth">
+          <Pair>
+            <key>normal</key>
+            <styleUrl>#fifth-normal</styleUrl>
+          </Pair>
+        </StyleMap>
+        <Placemark>
+            <name>fifth</name>
+            <styleUrl>#fifth</styleUrl>
+            <visibility>0</visibility>
+            <LineString>
+                <tessellate>0</tessellate>
+                <drawOrder>5</drawOrder>
+                <coordinates>
+                    6.087,52.509,0
+                    6.086,52.508,0
+                    6.085,52.507,0
+                    6.084,52.506,0
+                </coordinates>
+            </LineString>
+        </Placemark>
+
+        <!-- Sixth line -->
+        <Placemark>
+            <name>sixth</name>
+            <LineString>
+                <coordinates>
+                    6.087,52.509,0
+                    6.086,52.508,0
+                    6.085,52.507,0
+                    6.084,52.506,0
+                    6.083,52.505,0
+                    6.082,52.504,0
+                    6.081,52.503,0
+                    6.080,52.502,0
+                    6.079,52.501,0
+                    6.078,52.500,0
+                    6.077,52.499,0
+                    6.076,52.498,0
+                    6.075,52.497,0
+                    6.074,52.496,0
+                    6.073,52.495,0
+                    6.072,52.494,0
+                    6.071,52.493,0
+                    6.070,52.492,0
+                    6.069,52.491,0
+                    6.068,52.490,0
+                    6.067,52.489,0
+                    6.066,52.488,0
+                    6.065,52.487,0
+                    6.064,52.486,0
+                    6.063,52.485,0
+                    6.062,52.484,0
+                    6.061,52.483,0
+                    6.060,52.482,0
+                    6.059,52.481,0
+                    6.058,52.480,0
+                    6.057,52.479,0
+                    6.056,52.478,0
+                    6.055,52.477,0
+                    6.054,52.476,0
+                    6.053,52.475,0
+                    6.052,52.474,0
+                    6.051,52.473,0
+                    6.050,52.472,0
+                    6.049,52.471,0
+                    6.048,52.470,0
+                </coordinates>
+            </LineString>
+        </Placemark>
+    </Document>
+</kml>


### PR DESCRIPTION
Added Unittests for the parsing of KML `<LineString>` and `Polyline` setters.

# Fixes
- `convertPropertyToFloat` always returned defaultValue since it couldn't cast string to float automatically.