### PR TITLE
Improved style parsing

### DIFF
--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/data/KmlStyleId.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/data/KmlStyleId.kt
@@ -10,7 +10,9 @@ public abstract class KmlStyleId {
      *
      * @return id with # as prefix
      */
-    internal fun setId(id: String) {
-        styleId = if (id.startsWith("#")) id else "#${id}"
+    internal fun setId(id: String?) {
+        if (id != null) {
+            styleId = if (id.startsWith("#")) id else "#${id}"
+        }
     }
 }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
@@ -38,7 +38,7 @@ public class MarkerManager(
     ) {
         val styleUrl = markerData.value.styleUrl
         val normalStyleId = styleMaps[styleUrl]?.getNormalStyleId()
-        styles[normalStyleId]?.let { style = it }
+        style = styles[normalStyleId] ?: styles[styleUrl] ?: style
 
         generateIcon(images)
         applyStylesToProperties()

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
@@ -40,8 +40,8 @@ public class MarkerManager(
         val normalStyleId = styleMaps[styleUrl]?.getNormalStyleId()
         style = styles[normalStyleId] ?: styles[styleUrl] ?: style
 
-        generateIcon(images)
         applyStylesToProperties()
+        generateIcon(images)
     }
 
     /**

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/MarkerManager.kt
@@ -38,9 +38,8 @@ public class MarkerManager(
     ) {
         val styleUrl = markerData.value.styleUrl
         val normalStyleId = styleMaps[styleUrl]?.getNormalStyleId()
-        val selectedStyle = styles[normalStyleId]
+        styles[normalStyleId]?.let { style = it }
 
-        style = selectedStyle ?: KmlStyle()
         generateIcon(images)
         applyStylesToProperties()
     }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/PolylineManager.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/manager/PolylineManager.kt
@@ -46,9 +46,8 @@ public class PolylineManager(
     ) {
         val styleUrl = polylineData.value.styleUrl
         val normalStyleId = styleMaps[styleUrl]?.getNormalStyleId()
-        val selectedStyle = styles[normalStyleId]
+        style = styles[normalStyleId] ?: styles[styleUrl] ?: style
 
-        style = selectedStyle ?: KmlStyle()
         applyStylesToProperties()
     }
 

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlPlacemarkParser.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlPlacemarkParser.kt
@@ -1,6 +1,7 @@
 package com.google.maps.android.compose.kml.parser
 
 import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.kml.data.KmlStyle
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.COORDINATES_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.EXTENDED_DATA_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.LINE_STRING_TAG
@@ -8,6 +9,7 @@ import com.google.maps.android.compose.kml.data.KmlTags.Companion.MULTI_GEOMETRY
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.PLACEMARK_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.POINT_TAG
 import com.google.maps.android.compose.kml.data.KmlTags.Companion.POLYGON_TAG
+import com.google.maps.android.compose.kml.data.KmlTags.Companion.STYLE_TAG
 import com.google.maps.android.compose.kml.manager.ContainerManager
 import com.google.maps.android.compose.kml.manager.KmlComposableManager
 import com.google.maps.android.compose.kml.manager.MarkerManager
@@ -30,6 +32,7 @@ internal class KmlPlacemarkParser: KmlFeatureParser() {
             val properties: HashMap<String, Any> = hashMapOf()
             val extendedData: MutableList<ExtendedData> = mutableListOf()
             var placemark: KmlComposableManager? = null
+            var style: KmlStyle? = null
 
             while (!(eventType == XmlPullParser.END_TAG && parser.name == PLACEMARK_TAG)) {
                 if (eventType == XmlPullParser.START_TAG) {
@@ -47,6 +50,8 @@ internal class KmlPlacemarkParser: KmlFeatureParser() {
                         //TODO()
                     } else if (parser.name.equals(EXTENDED_DATA_TAG)) {
                         extendedData.addAll(parseExtendedData(parser))
+                    } else if (parser.name.equals(STYLE_TAG)) {
+                        style = KmlStyleParser.parseStyle(parser)
                     }
                 }
                 eventType = parser.next()
@@ -57,6 +62,9 @@ internal class KmlPlacemarkParser: KmlFeatureParser() {
 
             placemark?.let {
                 it.setProperties(properties)
+                if (style != null)
+                    it.style = style
+
                 container.addChild(it)
             }
         }

--- a/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlStyleParser.kt
+++ b/maps-compose-utils/src/main/java/com/google/maps/android/compose/kml/parser/KmlStyleParser.kt
@@ -248,6 +248,10 @@ internal class KmlStyleParser {
             return Color.rgb(red, green, blue)
         }
 
+        private fun setStyleId(style: KmlStyle, id: String) {
+
+        }
+
 
         private const val STYLE_MAP_NORMAL_STYLE = "normal"
         private const val COLOR_MODE_RANDOM = "random"


### PR DESCRIPTION
Instead of only relying on `<StyleMap>` tag in combination with `<Style>` tag the parser now supports three different notations.
- stylemap with syle - previously mentioned.
- inline style - `<Style>` tag defined inside of a `<Placemark>` tag
- single style - Single `<Style>` tag using an id to match to a `<Placemark>`s `<styleUrl>` without the use of a `<StyleMap>`